### PR TITLE
fix(build): Switch to stable rocker/r-ver base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM r-base@sha256:fa1972f31def171b83e0911e947ab8b57db143f0fc8a67af4c0d5ac329041646
+FROM rocker/r-ver@sha256:069e05d577c949039ba0c6b4e049240ae2796128077605dbfd6d3074fbc8a6dd
 
 ARG BOOKDOWN_VERSION=0.45
 ARG PANDOC_VERSION=3.8.2.1
@@ -13,8 +13,8 @@ LABEL org.opencontainers.image.source="https://github.com/fsbcg-ubt/docker-bookd
 LABEL org.opencontainers.image.version="0.4.2"
 LABEL org.opencontainers.image.licenses="MIT"
 
-LABEL org.opencontainers.image.base.name="registry.hub.docker.com/r-base"
-LABEL org.opencontainers.image.base.digest="sha256:fa1972f31def171b83e0911e947ab8b57db143f0fc8a67af4c0d5ac329041646"
+LABEL org.opencontainers.image.base.name="registry.hub.docker.com/rocker/r-ver"
+LABEL org.opencontainers.image.base.digest="sha256:069e05d577c949039ba0c6b4e049240ae2796128077605dbfd6d3074fbc8a6dd"
 
 LABEL maintainer="Martin Bens <martin.bens@uni-bayreuth.de>"
 LABEL r_version="4.4.2"
@@ -23,12 +23,14 @@ LABEL pandoc_version="${PANDOC_VERSION}"
 LABEL tinytex_version="${TINYTEX_VERSION}"
 LABEL r_tinytex_version="${R_TINYTEX_VERSION}"
 
+# Packages listed alphabetically
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     curl \
     libcurl4-openssl-dev \
     libssl-dev \
-    libxml2-dev
+    libxml2-dev \
+    wget
 
 RUN R -e "install.packages('bookdown',version='${BOOKDOWN_VERSION}',dependencies=TRUE)"
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## Acknowledgments
 
-Built on top of the official [r-base](https://hub.docker.com/_/r-base) Docker image and powered by:
+Built on top of the [rocker/r-ver](https://hub.docker.com/r/rocker/r-ver) Docker image and powered by:
 - The [bookdown](https://github.com/rstudio/bookdown) project by Yihui Xie
 - [Pandoc](https://pandoc.org/) by John MacFarlane
 - [TinyTeX](https://yihui.org/tinytex/) for LaTeX support


### PR DESCRIPTION
## Summary
Fixes Docker build failures caused by package dependency conflicts in Debian testing/sid by switching to a stable Ubuntu LTS base image.

Resolves #18

## Problem
The `r-base:latest` image uses Debian forky/sid (testing/unstable), which frequently has transient package conflicts during updates. This caused build failures with libcurl4t64 version mismatches between packages.

## Solution
Switch from `r-base` to `rocker/r-ver:4.5.1` which uses Ubuntu 24.04 LTS as the base. This provides:
- Stable package repositories with consistent versions
- Same R version (4.5.1)
- More reliable long-term builds
- Lower maintenance overhead

## Changes
- **Dockerfile**: Updated base image from `r-base@sha256:fa1972f...` to `rocker/r-ver@sha256:069e05d5...`
- **Dockerfile**: Updated base image labels to reference rocker/r-ver
- **Dockerfile**: Added `wget` to package list (required for Pandoc download script)
- **README.md**: Updated acknowledgments to reference rocker/r-ver base image